### PR TITLE
Synchronize menus and the test level

### DIFF
--- a/gameproject-1/.godot/editor/editor_layout.cfg
+++ b/gameproject-1/.godot/editor/editor_layout.cfg
@@ -2,30 +2,30 @@
 
 dock_3_selected_tab_idx=0
 dock_4_selected_tab_idx=0
-dock_5_selected_tab_idx=0
+dock_5_selected_tab_idx=1
 dock_floating={}
 dock_closed=[]
 dock_split_2=0
 dock_split_3=0
 dock_hsplit_1=0
 dock_hsplit_2=280
-dock_hsplit_3=-280
+dock_hsplit_3=-486
 dock_hsplit_4=0
+dock_9_selected_tab_idx=0
 dock_3="Scene,Import"
 dock_4="FileSystem,History"
 dock_5="Inspector,Signals,Groups"
-dock_9="Output,Debugger,Audio,Animation,Shader Editor,SpriteFrames,Search Results,AnimationTree,ResourcePreloader,ShaderFile,Theme,Polygon,TileSet,TileMap,Replication,GridMap"
-dock_9_selected_tab_idx=5
+dock_9="Output,Debugger,Audio,Animation,Shader Editor,Search Results,AnimationTree,ResourcePreloader,ShaderFile,SpriteFrames,Theme,Polygon,TileSet,TileMap,Replication,GridMap"
 
 [docks/FileSystem]
 
-h_split_offset=480
+h_split_offset=360
 v_split_offset=0
 display_mode=0
 file_sort=0
 file_list_display_mode=1
-selected_paths=PackedStringArray("res://")
-uncollapsed_paths=PackedStringArray("Favorites", "res://", "res://scripts/", "res://scenes/", "res://scenes/EnemyCharacter/", "res://assets/")
+selected_paths=PackedStringArray("res://pause.gd")
+uncollapsed_paths=PackedStringArray("Favorites", "res://", "res://scripts/EnemyScripts/", "res://Player/", "res://Player/Player_Script/")
 
 [docks/History]
 
@@ -34,42 +34,42 @@ include_global=true
 
 [EditorNode]
 
-open_scenes=PackedStringArray("res://scenes/EnemyCharacter/EnemyV1.tscn", "res://scenes/EnemyCharacter/killzone.tscn")
-current_scene="res://scenes/EnemyCharacter/EnemyV1.tscn"
+open_scenes=PackedStringArray("res://scenes/game.tscn", "res://scenes/platform.tscn", "res://main.tscn", "res://pause_menu.tscn", "res://main_menu.tscn")
+current_scene="res://main_menu.tscn"
 bottom_panel_offsets={
 "Animation": 0,
 "Audio": -450,
 "Debugger": 0,
 "Output": 0,
 "Shader Editor": 0,
-"SpriteFrames": 0
+"Theme": -551
 }
 selected_default_debugger_tab_idx=0
-selected_main_editor_idx=0
+selected_main_editor_idx=2
 
 [EditorWindow]
 
-screen=1
-mode="fullscreen"
-position=Vector2i(0, 0)
+screen=0
+mode="maximized"
+position=Vector2i(0, 34)
 
 [ScriptEditor]
 
-open_scripts=["res://scripts/EnemyScripts/killzone.gd", "res://scripts/EnemyScripts/LavaAnt.gd"]
-selected_script="res://scripts/EnemyScripts/LavaAnt.gd"
+open_scripts=["res://scripts/EnemyScripts/killzone.gd", "res://scripts/EnemyScripts/LavaAnt.gd", "res://main_menu.gd", "res://pause.gd", "res://Player/Player_Script/test_player.gd"]
+selected_script="res://main_menu.gd"
 open_help=[]
-script_split_offset=400
+script_split_offset=180
 list_split_offset=0
 zoom_factor=1.0
 
 [GameView]
 
-floating_window_rect=Rect2i(0, 0, 0, 0)
-floating_window_screen=-1
+floating_window_rect=Rect2i(696, 376, 1168, 720)
+floating_window_screen=0
 
 [ShaderEditor]
 
 open_shaders=[]
-split_offset=400
+split_offset=300
 selected_shader=""
 text_shader_zoom_factor=1.0

--- a/gameproject-1/.godot/editor/filesystem_cache10
+++ b/gameproject-1/.godot/editor/filesystem_cache10
@@ -1,48 +1,105 @@
 63f7b34db8d8cdea90c76aacccf841ec
-::res://::1773954613
-icon.svg::CompressedTexture2D::822653193914807282::1773418548::1773418578::1::::<><><>0<>0<>95e354c2323f1500a8f6057edb08b387<>res://.godot/imported/icon.svg-218a8f2b3041327d8a5756f3a245f83b.ctex::
-::res://assets/::1773954595
-::res://assets/EnemySprites/::1773954595
-::res://assets/EnemySprites/basic asset pack/::1773954595
-::res://assets/EnemySprites/basic asset pack/Basic Vermin Animations/::1773954595
-::res://assets/EnemySprites/basic asset pack/Basic Vermin Animations/Acid Ant/::1773954595
-AcidAnt.png::CompressedTexture2D::8510125247503674636::1773952774::1773954589::1::::<><><>0<>0<>d90dd3d98f9f629e34a4c42e397a0854<>res://.godot/imported/AcidAnt.png-17afaeab771cb6ed344c249c4f6a27be.ctex::
-::res://assets/EnemySprites/basic asset pack/Basic Vermin Animations/Bloated Bedbug/::1773954595
-BloatedBedbug.png::CompressedTexture2D::5687771957623588876::1773952774::1773954589::1::::<><><>0<>0<>ff8289054c6e6eab53e79cfceb585523<>res://.godot/imported/BloatedBedbug.png-4bc5330c9584f254bbe79040c3400264.ctex::
-::res://assets/EnemySprites/basic asset pack/Basic Vermin Animations/Dung Beetle/::1773954595
-DungBeetle.png::CompressedTexture2D::5197505184982395755::1773952774::1773954589::1::::<><><>0<>0<>222f7e796bde098535ac8d394cd2b008<>res://.godot/imported/DungBeetle.png-3e55bc71b49753599b1b2973f0c4d6f2.ctex::
-::res://assets/EnemySprites/basic asset pack/Basic Vermin Animations/Engorged Tick/::1773954595
-EngorgedTick.png::CompressedTexture2D::6187485494181248553::1773952774::1773954589::1::::<><><>0<>0<>d2c322ed9c3a7237474fe2c0a12027cf<>res://.godot/imported/EngorgedTick.png-1e6560f166c95c2600698d53030243d0.ctex::
-::res://assets/EnemySprites/basic asset pack/Basic Vermin Animations/Famished Tick/::1773954595
-FamishedTick.png::CompressedTexture2D::4387039195865652360::1773952774::1773954589::1::::<><><>0<>0<>9861bc6efa03e60a45f7e3db580b3063<>res://.godot/imported/FamishedTick.png-ab0f754647a714137a55aaf038fbb43a.ctex::
-::res://assets/EnemySprites/basic asset pack/Basic Vermin Animations/Foraging Maggot/::1773954595
-ForagingMaggot.png::CompressedTexture2D::3079685318119881245::1773952774::1773954589::1::::<><><>0<>0<>8ae31d0322d6b434ffc955e2f48b6624<>res://.godot/imported/ForagingMaggot.png-abad8087709114da89081e0244455163.ctex::
-::res://assets/EnemySprites/basic asset pack/Basic Vermin Animations/Infected Mouse/::1773954595
-InfectedMouse.png::CompressedTexture2D::2106014867123592587::1773952774::1773954589::1::::<><><>0<>0<>dc224fc94f09f64aec920acaf580a87b<>res://.godot/imported/InfectedMouse.png-81da09354d57daae13a671420bf48d36.ctex::
-::res://assets/EnemySprites/basic asset pack/Basic Vermin Animations/Lava Ant/::1773954595
-LavaAnt.png::CompressedTexture2D::3013355579087132789::1773952774::1773954589::1::::<><><>0<>0<>e79f78c40acc4db93994f00636cbbe60<>res://.godot/imported/LavaAnt.png-913f6b50e852ab1322695ad8fe06e2d7.ctex::
-::res://assets/EnemySprites/basic asset pack/Basic Vermin Animations/Mawing Beaver/::1773954595
-MawingBeaver.png::CompressedTexture2D::2357008316670551651::1773952774::1773954589::1::::<><><>0<>0<>8abb0ed88a82784797b02dbc83b5f104<>res://.godot/imported/MawingBeaver.png-c32797d07a12fc42c019f0310fd287eb.ctex::
-::res://assets/EnemySprites/basic asset pack/Basic Vermin Animations/Plague Bat/::1773954595
-PlagueBat.png::CompressedTexture2D::9014455340236078484::1773952774::1773954589::1::::<><><>0<>0<>35170b5e1d1bfa815f8870c83c5d08a3<>res://.godot/imported/PlagueBat.png-a57e77424199e5ca2a232f1ad82cc256.ctex::
-::res://assets/EnemySprites/basic asset pack/Basic Vermin Animations/Rhino Beetle/::1773954595
-RhinoBeetle.png::CompressedTexture2D::2438257846285764963::1773952774::1773954589::1::::<><><>0<>0<>04b42a003ad89cb39a975afa437cc4e6<>res://.godot/imported/RhinoBeetle.png-a363bf1a02d75aca34b2364eb35ab9db.ctex::
-::res://assets/EnemySprites/basic asset pack/Basic Vermin Animations/Soldier Ant/::1773954595
-SoldierAnt.png::CompressedTexture2D::7190691099148291837::1773952774::1773954589::1::::<><><>0<>0<>7f846d010b1d812eafb724eb68facf5c<>res://.godot/imported/SoldierAnt.png-9ea7382caab379e7824b3ac9519af614.ctex::
-::res://assets/EnemySprites/basic asset pack/Basic Vermin Animations/Swooping Bat/::1773954591
-SwoopingBat.png::CompressedTexture2D::5105672779440586018::1773952774::1773954589::1::::<><><>0<>0<>4ca06c621c4d3a0833a69bef0dad95f4<>res://.godot/imported/SwoopingBat.png-a0ecff17b9ec88cb12f35a9ab77cebf8.ctex::
-::res://assets/EnemySprites/basic asset pack/Basic Vermin Animations/Tainted Cockroach/::1773954595
-TaintedCockroach.png::CompressedTexture2D::6247971241884831688::1773952774::1773954589::1::::<><><>0<>0<>78b86bfd35db24a1f803e80e758cb6cf<>res://.godot/imported/TaintedCockroach.png-667d24c49f7ccce3fa89f59c7408da86.ctex::
-::res://assets/EnemySprites/basic asset pack/Basic Vermin Animations/Tunneling Mole/::1773954595
-TunnelingMole.png::CompressedTexture2D::3298795601583983291::1773952774::1773954589::1::::<><><>0<>0<>adb5b81de6e90330121e0ec5ab8a5bf7<>res://.godot/imported/TunnelingMole.png-4c4754bec6b60ada538bacdb3da68639.ctex::
-::res://assets/EnemySprites/basic asset pack/Basic Vermin Sprites/::1773954595
-Basic Vermin 1x.png::CompressedTexture2D::3906352122593502971::1773952774::1773954589::1::::<><><>0<>0<>83bcf87eae3c33a9e60d563da0e1ddfe<>res://.godot/imported/Basic Vermin 1x.png-e22caaef3ec1a0b8d077626d29defec0.ctex::
-Basic Vermin 2x.png::CompressedTexture2D::399744622203423679::1773952774::1773954589::1::::<><><>0<>0<>61b21cc3b0ccff1b5661d9016026d05b<>res://.godot/imported/Basic Vermin 2x.png-92f4b5c1e95ec23eb52f00374d05bcc4.ctex::
-Basic Vermin 4x.png::CompressedTexture2D::6048719973935122646::1773952774::1773954589::1::::<><><>0<>0<>edbde5fb4581c90746d5ca83caf84332<>res://.godot/imported/Basic Vermin 4x.png-bdbd2a17e8e7ef353150573181f1bb2a.ctex::
-::res://scenes/::1773954595
-::res://scenes/EnemyCharacter/::1773954595
-EnemyV1.tscn::PackedScene::7511965277569014200::1773954589::0::1::::<><><>0<>0<><>::uid://bi6xr5hbshg2p::::res://assets/EnemySprites/basic asset pack/Basic Vermin Animations/Lava Ant/LavaAnt.png
-killzone.tscn::PackedScene::7889324522071393493::1773954019::0::1::::<><><>0<>0<><>::
-::res://scripts/::1773954476
-::res://scripts/EnemyScripts/::0
-killzone.gd::GDScript::2222086862563583673::1773954473::0::1::::<>Area2D<><>0<>0<><>::
+::res://::1773969029
+icon.svg::CompressedTexture2D::822653193914807282::1773417641::1773417771::1::::<><><>0<>0<>95e354c2323f1500a8f6057edb08b387<>res://.godot/imported/icon.svg-218a8f2b3041327d8a5756f3a245f83b.ctex::
+main.tscn::PackedScene::1483519777991313823::1773968998::0::1::::<><><>0<>0<><>::
+main_menu.gd::GDScript::1616854304289779440::1773968998::0::1::::<>Control<><>0<>0<><>::
+main_menu.tscn::PackedScene::6053563071779595488::1773968998::0::1::::<><><>0<>0<><>::uid://xbhmboffhejg::::res://main_menu.gd
+pause.gd::GDScript::9061455581485792194::1773958342::0::1::::<>Node<><>0<>0<><>::
+pause_menu.tscn::PackedScene::1377678192176669719::1773960560::0::1::::<><><>0<>0<><>::uid://d2do35b88pbgk::::res://pause.gd
+::res://assets/::1773968997
+::res://assets/EnemySprites/::1773968997
+::res://assets/EnemySprites/basic asset pack/::1773968997
+::res://assets/EnemySprites/basic asset pack/Basic Vermin Animations/::1773968997
+::res://assets/EnemySprites/basic asset pack/Basic Vermin Animations/Acid Ant/::1773968997
+AcidAnt.png::CompressedTexture2D::8510125247503674636::1773968997::1773968997::1::::<><><>0<>0<>d90dd3d98f9f629e34a4c42e397a0854<>res://.godot/imported/AcidAnt.png-17afaeab771cb6ed344c249c4f6a27be.ctex::
+::res://assets/EnemySprites/basic asset pack/Basic Vermin Animations/Bloated Bedbug/::1773968997
+BloatedBedbug.png::CompressedTexture2D::5687771957623588876::1773968997::1773968997::1::::<><><>0<>0<>ff8289054c6e6eab53e79cfceb585523<>res://.godot/imported/BloatedBedbug.png-4bc5330c9584f254bbe79040c3400264.ctex::
+::res://assets/EnemySprites/basic asset pack/Basic Vermin Animations/Dung Beetle/::1773968997
+DungBeetle.png::CompressedTexture2D::5197505184982395755::1773968997::1773968997::1::::<><><>0<>0<>222f7e796bde098535ac8d394cd2b008<>res://.godot/imported/DungBeetle.png-3e55bc71b49753599b1b2973f0c4d6f2.ctex::
+::res://assets/EnemySprites/basic asset pack/Basic Vermin Animations/Engorged Tick/::1773968997
+EngorgedTick.png::CompressedTexture2D::6187485494181248553::1773968997::1773968997::1::::<><><>0<>0<>d2c322ed9c3a7237474fe2c0a12027cf<>res://.godot/imported/EngorgedTick.png-1e6560f166c95c2600698d53030243d0.ctex::
+::res://assets/EnemySprites/basic asset pack/Basic Vermin Animations/Famished Tick/::1773968997
+FamishedTick.png::CompressedTexture2D::4387039195865652360::1773968997::1773968997::1::::<><><>0<>0<>9861bc6efa03e60a45f7e3db580b3063<>res://.godot/imported/FamishedTick.png-ab0f754647a714137a55aaf038fbb43a.ctex::
+::res://assets/EnemySprites/basic asset pack/Basic Vermin Animations/Foraging Maggot/::1773968997
+ForagingMaggot.png::CompressedTexture2D::3079685318119881245::1773968997::1773968997::1::::<><><>0<>0<>8ae31d0322d6b434ffc955e2f48b6624<>res://.godot/imported/ForagingMaggot.png-abad8087709114da89081e0244455163.ctex::
+::res://assets/EnemySprites/basic asset pack/Basic Vermin Animations/Infected Mouse/::1773968997
+InfectedMouse.png::CompressedTexture2D::2106014867123592587::1773968997::1773968997::1::::<><><>0<>0<>dc224fc94f09f64aec920acaf580a87b<>res://.godot/imported/InfectedMouse.png-81da09354d57daae13a671420bf48d36.ctex::
+::res://assets/EnemySprites/basic asset pack/Basic Vermin Animations/Lava Ant/::1773968997
+LavaAnt.png::CompressedTexture2D::3013355579087132789::1773968997::1773968997::1::::<><><>0<>0<>e79f78c40acc4db93994f00636cbbe60<>res://.godot/imported/LavaAnt.png-913f6b50e852ab1322695ad8fe06e2d7.ctex::
+::res://assets/EnemySprites/basic asset pack/Basic Vermin Animations/Mawing Beaver/::1773968997
+MawingBeaver.png::CompressedTexture2D::2357008316670551651::1773968997::1773968997::1::::<><><>0<>0<>8abb0ed88a82784797b02dbc83b5f104<>res://.godot/imported/MawingBeaver.png-c32797d07a12fc42c019f0310fd287eb.ctex::
+::res://assets/EnemySprites/basic asset pack/Basic Vermin Animations/Plague Bat/::1773968997
+PlagueBat.png::CompressedTexture2D::9014455340236078484::1773968997::1773968997::1::::<><><>0<>0<>35170b5e1d1bfa815f8870c83c5d08a3<>res://.godot/imported/PlagueBat.png-a57e77424199e5ca2a232f1ad82cc256.ctex::
+::res://assets/EnemySprites/basic asset pack/Basic Vermin Animations/Rhino Beetle/::1773968997
+RhinoBeetle.png::CompressedTexture2D::2438257846285764963::1773968997::1773968997::1::::<><><>0<>0<>04b42a003ad89cb39a975afa437cc4e6<>res://.godot/imported/RhinoBeetle.png-a363bf1a02d75aca34b2364eb35ab9db.ctex::
+::res://assets/EnemySprites/basic asset pack/Basic Vermin Animations/Soldier Ant/::1773968997
+SoldierAnt.png::CompressedTexture2D::7190691099148291837::1773968997::1773968997::1::::<><><>0<>0<>7f846d010b1d812eafb724eb68facf5c<>res://.godot/imported/SoldierAnt.png-9ea7382caab379e7824b3ac9519af614.ctex::
+::res://assets/EnemySprites/basic asset pack/Basic Vermin Animations/Swooping Bat/::1773968997
+SwoopingBat.png::CompressedTexture2D::5105672779440586018::1773968997::1773968997::1::::<><><>0<>0<>4ca06c621c4d3a0833a69bef0dad95f4<>res://.godot/imported/SwoopingBat.png-a0ecff17b9ec88cb12f35a9ab77cebf8.ctex::
+::res://assets/EnemySprites/basic asset pack/Basic Vermin Animations/Tainted Cockroach/::1773968997
+TaintedCockroach.png::CompressedTexture2D::6247971241884831688::1773968997::1773968997::1::::<><><>0<>0<>78b86bfd35db24a1f803e80e758cb6cf<>res://.godot/imported/TaintedCockroach.png-667d24c49f7ccce3fa89f59c7408da86.ctex::
+::res://assets/EnemySprites/basic asset pack/Basic Vermin Animations/Tunneling Mole/::1773968997
+TunnelingMole.png::CompressedTexture2D::3298795601583983291::1773968997::1773968997::1::::<><><>0<>0<>adb5b81de6e90330121e0ec5ab8a5bf7<>res://.godot/imported/TunnelingMole.png-4c4754bec6b60ada538bacdb3da68639.ctex::
+::res://assets/EnemySprites/basic asset pack/Basic Vermin Sprites/::1773968997
+Basic Vermin 1x.png::CompressedTexture2D::3906352122593502971::1773968997::1773968997::1::::<><><>0<>0<>83bcf87eae3c33a9e60d563da0e1ddfe<>res://.godot/imported/Basic Vermin 1x.png-e22caaef3ec1a0b8d077626d29defec0.ctex::
+Basic Vermin 2x.png::CompressedTexture2D::399744622203423679::1773968997::1773968997::1::::<><><>0<>0<>61b21cc3b0ccff1b5661d9016026d05b<>res://.godot/imported/Basic Vermin 2x.png-92f4b5c1e95ec23eb52f00374d05bcc4.ctex::
+Basic Vermin 4x.png::CompressedTexture2D::6048719973935122646::1773968997::1773968997::1::::<><><>0<>0<>edbde5fb4581c90746d5ca83caf84332<>res://.godot/imported/Basic Vermin 4x.png-bdbd2a17e8e7ef353150573181f1bb2a.ctex::
+::res://assets/fonts/::1773968997
+PixelOperator8-Bold.ttf::FontFile::9154690205291948519::1773968997::1773969031::1::::<><><>0<>0<>5f7172e32cc0aa74158d66d49aaa1266<>res://.godot/imported/PixelOperator8-Bold.ttf-74faf550739674ad3170f08e646e0614.fontdata::
+PixelOperator8.ttf::FontFile::3217866226561902138::1773968997::1773969031::1::::<><><>0<>0<>b1d4b4db7e344f559788a0705f91654e<>res://.godot/imported/PixelOperator8.ttf-6f9f01766aff16f52046b880ffb8d367.fontdata::
+::res://assets/music/::1773968997
+time_for_adventure.mp3::AudioStreamMP3::4948709501560589639::1773968997::1773969031::1::::<><><>0<>0<>b07c436a90ddeaf93507371f1dc89617<>res://.godot/imported/time_for_adventure.mp3-b8a49ae1cfc83b211be9d82e6e985655.mp3str::
+::res://assets/sounds/::1773968997
+coin.wav::AudioStreamWAV::907757356929266493::1773968997::1773969031::1::::<><><>0<>0<>96cb3bacbc9ec569bf5f1ff245261fc9<>res://.godot/imported/coin.wav-9081ee1c6d81d9c34d08bc916297b892.sample::
+explosion.wav::AudioStreamWAV::9127341246642468578::1773968997::1773969031::1::::<><><>0<>0<>79130e0054ae1a8ef869f153677dc5f0<>res://.godot/imported/explosion.wav-52e05e8d4b6600106c8dde082c90f915.sample::
+hurt.wav::AudioStreamWAV::5728456655277898296::1773968997::1773969031::1::::<><><>0<>0<>6dd1100df8e838990b4a98b0346bd9c9<>res://.godot/imported/hurt.wav-792baeb99505afd6a1496d4e4330b023.sample::
+jump.wav::AudioStreamWAV::5553597477252394833::1773968997::1773969031::1::::<><><>0<>0<>dab285f7b10381be0f9c156978c8160f<>res://.godot/imported/jump.wav-395b727cde98999423d5c020c9c3492f.sample::
+power_up.wav::AudioStreamWAV::4282735600552481238::1773968997::1773969031::1::::<><><>0<>0<>07d42270564150a321216e1acf147fe1<>res://.godot/imported/power_up.wav-8349ffe570559470036ebff4b80f7fc0.sample::
+tap.wav::AudioStreamWAV::5560549480260508210::1773968997::1773969031::1::::<><><>0<>0<>705e4a1fd768bd655a6e0f146d1602ed<>res://.godot/imported/tap.wav-78d4c5a48b21a853d89bec74f20510e7.sample::
+::res://assets/sprites/::1773968997
+coin.png::CompressedTexture2D::2786001246281601476::1773968997::1773969031::1::::<><><>0<>0<>8253bb5c79bfe946c4e408adb6705106<>res://.godot/imported/coin.png-c8309bf0f8fb5f3a7d1e96a4eb3f02ce.ctex::
+fruit.png::CompressedTexture2D::8489279778303373256::1773968997::1773969031::1::::<><><>0<>0<>41cfea1ab876895baeda8b0eefaf7a56<>res://.godot/imported/fruit.png-3735163b668af10c2b35b52cba81b68a.ctex::
+knight.png::CompressedTexture2D::3742995390958986796::1773968997::1773969031::1::::<><><>0<>0<>0142af80e73666e926e442c9057019bb<>res://.godot/imported/knight.png-7c67c83d34932624952797d9e971a644.ctex::
+platforms.png::CompressedTexture2D::8966698930851432894::1773968997::1773969031::1::::<><><>0<>0<>9a2d5b48fdcdbd268b619fcb397c252a<>res://.godot/imported/platforms.png-3869606db457611ed4193d705dc364e4.ctex::
+slime_green.png::CompressedTexture2D::1614325635370631561::1773968997::1773969031::1::::<><><>0<>0<>7f3522efa79665a3d0bd83dd584da61b<>res://.godot/imported/slime_green.png-f6349164bf3a0f5189bb927b97af9c58.ctex::
+slime_purple.png::CompressedTexture2D::714027411279532166::1773968997::1773969031::1::::<><><>0<>0<>80b3c7259b325337bedd15a97dd279e7<>res://.godot/imported/slime_purple.png-26dc5ddef235ce6a400e78e0d532b050.ctex::
+world_tileset.png::CompressedTexture2D::5940887836741968287::1773968997::1773969031::1::::<><><>0<>0<>5e63ff936662a97e45a294218423762e<>res://.godot/imported/world_tileset.png-61a32465f33c3d9d3bfecb75b6485009.ctex::
+::res://assets/test/::1773968997
+::res://assets/test/brackeys_platformer_assets/::1773968998
+LICENSE & CREDITS.txt::TextFile::-1::1773968997::0::1::::<><><>0<>0<><>::
+::res://assets/test/brackeys_platformer_assets/fonts/::1773968997
+PixelOperator8-Bold.ttf::FontFile::1131362604725373736::1773968997::1773969031::1::::<><><>0<>0<>26a9a93903f86f548013ec4fbbe13fe6<>res://.godot/imported/PixelOperator8-Bold.ttf-91368576aa9a3309c10dc4bccbad5311.fontdata::
+PixelOperator8.ttf::FontFile::6052196976777727020::1773968997::1773969031::1::::<><><>0<>0<>3741e5b274167b39aafa679aeca3c967<>res://.godot/imported/PixelOperator8.ttf-aa52272cd217ca020c3a91478d7912ca.fontdata::
+::res://assets/test/brackeys_platformer_assets/music/::1773968998
+time_for_adventure.mp3::AudioStreamMP3::2216736307024590576::1773968998::1773969031::1::::<><><>0<>0<>48c0423401c044c752e2751752e0a6e5<>res://.godot/imported/time_for_adventure.mp3-16bf0d7a36620c135140c4fe25f6c117.mp3str::
+::res://assets/test/brackeys_platformer_assets/sounds/::1773968998
+coin.wav::AudioStreamWAV::3711229136336095980::1773968998::1773969031::1::::<><><>0<>0<>b8ad6a2da345b0c6bd2bd174ce5a6ee0<>res://.godot/imported/coin.wav-5ae2d2777df5718e1ebcdd4f5f0aa5c1.sample::
+explosion.wav::AudioStreamWAV::6061427951322086792::1773968998::1773969031::1::::<><><>0<>0<>188cd320af42046f0ca8709f1165f378<>res://.godot/imported/explosion.wav-362023886fd828915c7161179b73e5fe.sample::
+hurt.wav::AudioStreamWAV::7371602050253126333::1773968998::1773969031::1::::<><><>0<>0<>c9a78c0e4475e61fa97e0bb7563d375a<>res://.godot/imported/hurt.wav-f8accd1d1cd7d90fc1e2d234b294a3f1.sample::
+jump.wav::AudioStreamWAV::2309179893195537895::1773968998::1773969031::1::::<><><>0<>0<>c6f23f3e53e8767495bd2b6a7149dab4<>res://.godot/imported/jump.wav-4db3f6a47e403d0f6b67e1677e4292ec.sample::
+power_up.wav::AudioStreamWAV::4220406304040556944::1773968998::1773969031::1::::<><><>0<>0<>b4443a8eedfea99755f04ef3cfd53095<>res://.godot/imported/power_up.wav-c8ca7b915f2dc53e0463216078bd964d.sample::
+tap.wav::AudioStreamWAV::2881928797857756508::1773968998::1773969031::1::::<><><>0<>0<>001282176e885bda8c1781920c952d53<>res://.godot/imported/tap.wav-d95bec7de6824fe1329baf8341c1ddff.sample::
+::res://assets/test/brackeys_platformer_assets/sprites/::1773968998
+coin.png::CompressedTexture2D::1302098911885346490::1773968998::1773969031::1::::<><><>0<>0<>10b5109019a3eb244f22765673ad55f5<>res://.godot/imported/coin.png-06c61bbca167388fbd5fa6137139e4c1.ctex::
+fruit.png::CompressedTexture2D::5874906952762724249::1773968998::1773969031::1::::<><><>0<>0<>76db32a894495cf6374ab3814310ccd9<>res://.godot/imported/fruit.png-cebcd7244f8254b5deeec8ceb123159e.ctex::
+knight.png::CompressedTexture2D::983423645383088466::1773968998::1773969031::1::::<><><>0<>0<>40e53e2b358910b3b90b9377994211f6<>res://.godot/imported/knight.png-cf763ad95e4609347c7648c15e5debbd.ctex::
+platforms.png::CompressedTexture2D::1326670105611892800::1773968998::1773969031::1::::<><><>0<>0<>e81e1b043e9592f3815e41b0f83596e5<>res://.godot/imported/platforms.png-5cd7e933c1f0b3f24156cadf72d4e346.ctex::
+slime_green.png::CompressedTexture2D::3406510118556333028::1773968998::1773969031::1::::<><><>0<>0<>d3eb47c2379aab49c116cf813ebab3a4<>res://.godot/imported/slime_green.png-ca6ce07a0f6b547268e314291f657389.ctex::
+slime_purple.png::CompressedTexture2D::5600717993488766826::1773968998::1773969031::1::::<><><>0<>0<>aafecc93f95820cc13f5d6546dc1090e<>res://.godot/imported/slime_purple.png-7b29a54f74bf154424c99d139279c003.ctex::
+world_tileset.png::CompressedTexture2D::6107173484287005987::1773968998::1773969031::1::::<><><>0<>0<>243e788902c0d0fa1f68c790ee10eacf<>res://.godot/imported/world_tileset.png-ed1cecf9ff0da37e6a6daeeb09bb013c.ctex::
+::res://Map/::1773968997
+test_level.tscn::PackedScene::7035549513384774881::1773968997::0::1::::<><><>0<>0<><>::uid://ocyoc1083cuv::::res://Player/test_player.tscn
+::res://Player/::1773968997
+test_player.tscn::PackedScene::988254921774339925::1773968997::0::1::::<><><>0<>0<><>::uid://jxk2qktqjuk5::::res://Player/Player_Script/test_player.gd<>uid://oam3xnefeh5k::::res://Assets/test/brackeys_platformer_assets/sprites/knight.png
+::res://Player/Player_Script/::1773968997
+test_player.gd::GDScript::679836524155441258::1773968997::0::1::::<>CharacterBody2D<><>0<>0<><>::
+::res://scenes/::1773968998
+game.tscn::PackedScene::3210558460310417428::1773968998::0::1::::<><><>0<>0<><>::uid://cqv2s4h18uqi6::::res://assets/sprites/world_tileset.png<>uid://d30iq1mq7lcnp::::res://scenes/platform.tscn
+platform.tscn::PackedScene::9176674810355235753::1773968998::0::1::::<><><>0<>0<><>::uid://d00shr4svncs1::::res://assets/sprites/platforms.png
+::res://scenes/EnemyCharacter/::1773968998
+EnemyV1.tscn::PackedScene::7511965277569014200::1773968998::0::1::::<><><>0<>0<><>::uid://bi6xr5hbshg2p::::res://assets/EnemySprites/basic asset pack/Basic Vermin Animations/Lava Ant/LavaAnt.png<>uid://bhlqb2w0bekmu::::res://scripts/EnemyScripts/LavaAnt.gd<>uid://dknwa0x42eftl::::res://scenes/EnemyCharacter/killzone.tscn
+killzone.tscn::PackedScene::7889324522071393493::1773968998::0::1::::<><><>0<>0<><>::uid://6wnpfsvcrku8::::res://scripts/EnemyScripts/killzone.gd
+::res://scripts/::1773968998
+::res://scripts/EnemyScripts/::1773968998
+killzone.gd::GDScript::2222086862563583673::1773968998::0::1::::<>Area2D<><>0<>0<><>::
+LavaAnt.gd::GDScript::2901425455385695780::1773968998::0::1::::<>Node2D<><>0<>0<><>::

--- a/gameproject-1/.godot/editor/filesystem_update4
+++ b/gameproject-1/.godot/editor/filesystem_update4
@@ -1,5 +1,7 @@
-res://scripts/killzone.gd
-res://scripts/EnemyScripts/killzone.gd
-res://scenes/EnemyCharacter/killzone.tscn
-res://scenes/EnemyCharacter/EnemyV1.tscn
-res://scripts/EnemyScripts/LavaAnt.gd
+res://scenes/platform.tscn
+res://pause.gd
+res://Player/Player_Script/test_player.gd
+res://main_menu.gd
+res://pause_menu.tscn
+res://main.tscn
+res://main_menu.tscn

--- a/gameproject-1/.godot/editor/project_metadata.cfg
+++ b/gameproject-1/.godot/editor/project_metadata.cfg
@@ -4,17 +4,18 @@ select_mode=0
 
 [editor_metadata]
 
-executable_path="/Applications/Godot.app/Contents/MacOS/Godot"
+executable_path="C:/Users/marsh/Downloads/Godot_v4.6.1-stable_win64.exe/Godot_v4.6.1-stable_win64.exe"
 use_advanced_connections=false
 
 [dialog_bounds]
 
 create_new_node=Rect2(1016, 380, 1800, 1400)
+project_settings=Rect2(380, 275, 1800, 1050)
 
 [recent_files]
 
-scenes=["res://scenes/EnemyCharacter/killzone.tscn", "res://scenes/EnemyCharacter/EnemyV1.tscn", "res://scenes/killzone.tscn", "res://scenes/EnemyV1.tscn"]
-scripts=["res://scripts/EnemyScripts/LavaAnt.gd", "res://scripts/killzone.gd"]
+scenes=["res://main_menu.tscn", "res://pause_menu.tscn", "res://main.tscn", "res://scenes/platform.tscn", "res://scenes/game.tscn", "res://scenes/EnemyCharacter/killzone.tscn", "res://scenes/EnemyCharacter/EnemyV1.tscn", "res://scenes/killzone.tscn", "res://scenes/EnemyV1.tscn"]
+scripts=["res://main_menu.gd", "res://Player/Player_Script/test_player.gd", "res://scripts/EnemyScripts/LavaAnt.gd", "res://scripts/EnemyScripts/killzone.gd", "res://scripts/killzone.gd"]
 
 [quick_open_dialog]
 

--- a/gameproject-1/.godot/editor/script_editor_cache.cfg
+++ b/gameproject-1/.godot/editor/script_editor_cache.cfg
@@ -1,12 +1,26 @@
+[res://pause.gd]
+
+state={
+"bookmarks": PackedInt32Array(),
+"breakpoints": PackedInt32Array(),
+"column": 0,
+"folded_lines": PackedInt32Array(),
+"h_scroll_position": 0,
+"row": 7,
+"scroll_position": 0.0,
+"selection": false,
+"syntax_highlighter": "GDScript"
+}
+
 [res://scripts/EnemyScripts/killzone.gd]
 
 state={
 "bookmarks": PackedInt32Array(),
 "breakpoints": PackedInt32Array(),
-"column": 34,
+"column": 0,
 "folded_lines": PackedInt32Array(),
 "h_scroll_position": 0,
-"row": 12,
+"row": 0,
 "scroll_position": 0.0,
 "selection": false,
 "syntax_highlighter": "GDScript"
@@ -17,10 +31,38 @@ state={
 state={
 "bookmarks": PackedInt32Array(),
 "breakpoints": PackedInt32Array(),
-"column": 32,
+"column": 0,
 "folded_lines": PackedInt32Array(),
 "h_scroll_position": 0,
-"row": 18,
+"row": 0,
+"scroll_position": 0.0,
+"selection": false,
+"syntax_highlighter": "GDScript"
+}
+
+[res://Player/Player_Script/test_player.gd]
+
+state={
+"bookmarks": PackedInt32Array(),
+"breakpoints": PackedInt32Array(),
+"column": 0,
+"folded_lines": PackedInt32Array(),
+"h_scroll_position": 0,
+"row": 49,
+"scroll_position": 0.0,
+"selection": false,
+"syntax_highlighter": "GDScript"
+}
+
+[res://main_menu.gd]
+
+state={
+"bookmarks": PackedInt32Array(),
+"breakpoints": PackedInt32Array(),
+"column": 0,
+"folded_lines": PackedInt32Array(),
+"h_scroll_position": 0,
+"row": 2,
 "scroll_position": 0.0,
 "selection": false,
 "syntax_highlighter": "GDScript"

--- a/gameproject-1/Player/Player_Script/test_player.gd
+++ b/gameproject-1/Player/Player_Script/test_player.gd
@@ -47,3 +47,9 @@ func basic_movement(delta: float) -> void:
 		velocity.x = direction * speed
 	else:
 		velocity.x = move_toward(velocity.x, 0, speed)
+
+func _input(event):
+	if event is InputEventKey and event.pressed:
+		if event.keycode == KEY_ESCAPE:
+			#Go to pause menu if Esc key pressed
+			get_tree().change_scene_to_file("res://pause_menu.tscn");

--- a/gameproject-1/main_menu.gd
+++ b/gameproject-1/main_menu.gd
@@ -15,6 +15,7 @@ func _process(delta: float) -> void:
 
 func _on_new_game_pressed() -> void:
 	print("Start new game")
+	get_tree().change_scene_to_file("res://Map/test_level.tscn");
 
 
 func _on_continue_pressed() -> void:

--- a/gameproject-1/main_menu.tscn
+++ b/gameproject-1/main_menu.tscn
@@ -65,3 +65,4 @@ text = "Quit"
 [connection signal="pressed" from="Container/NewGame" to="." method="_on_new_game_pressed"]
 [connection signal="pressed" from="Container/Continue" to="." method="_on_continue_pressed"]
 [connection signal="pressed" from="Container/Options" to="." method="_on_options_pressed"]
+[connection signal="pressed" from="Container/Quit" to="." method="_on_quit_pressed"]

--- a/gameproject-1/pause.gd
+++ b/gameproject-1/pause.gd
@@ -1,13 +1,13 @@
 extends Node
 
-func _inpt(event):
+func _input(event):
 	if event is InputEventKey and event.pressed:
 		if event.keycode == KEY_ESCAPE:
 			#Go back to game if user hits Esc key (unpause)
-			get_tree().change_scene_to_file("res://game.tscn");
+			get_tree().change_scene_to_file("res://Map/test_level.tscn");
 
 func _on_resume_pressed() -> void:
-	get_tree().change_scene_to_file("res://game.tscn");
+	get_tree().change_scene_to_file("res://Map/test_level.tscn");
 
 func _on_main_menu_pressed() -> void:
 	get_tree().change_scene_to_file("res://main_menu.tscn");

--- a/gameproject-1/project.godot
+++ b/gameproject-1/project.godot
@@ -11,7 +11,7 @@ config_version=5
 [application]
 
 config/name="GAMEPROJECT1"
-run/main_scene="uid://c7icqckicdyy0"
+run/main_scene="uid://csinkgb4vsn8k"
 config/features=PackedStringArray("4.6", "Forward Plus")
 config/icon="res://icon.svg"
 


### PR DESCRIPTION
Added pause with the Esc key for test_player, fixed paths in pause.gd, a disconnected node in main_menu.